### PR TITLE
✨ feat [#140] shipping, shippingLog 양방향 매핑 관계설정

### DIFF
--- a/shipping-service/src/main/java/com/sparta/shippingservice/application/dto/client/HubRouteInfoResponse.java
+++ b/shipping-service/src/main/java/com/sparta/shippingservice/application/dto/client/HubRouteInfoResponse.java
@@ -1,0 +1,11 @@
+package com.sparta.shippingservice.application.dto.client;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record HubRouteInfoResponse(
+        UUID startHubId,
+        UUID endHubId,
+        BigDecimal estimatedDistance,
+        Integer estimatedTime
+) {}

--- a/shipping-service/src/main/java/com/sparta/shippingservice/application/dto/request/CreateRouteLogRequestDto.java
+++ b/shipping-service/src/main/java/com/sparta/shippingservice/application/dto/request/CreateRouteLogRequestDto.java
@@ -1,8 +1,7 @@
 package com.sparta.shippingservice.application.dto.request;
 
-import com.sparta.shippingservice.domain.model.RouteLogSelf;
+import com.sparta.shippingservice.domain.model.trans.RouteLogSelf;
 import com.sparta.shippingservice.domain.model.Shipping;
-import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 

--- a/shipping-service/src/main/java/com/sparta/shippingservice/application/dto/request/CreateShippingRequestDto.java
+++ b/shipping-service/src/main/java/com/sparta/shippingservice/application/dto/request/CreateShippingRequestDto.java
@@ -1,6 +1,6 @@
 package com.sparta.shippingservice.application.dto.request;
 
-import com.sparta.shippingservice.domain.model.ShippingSelf;
+import com.sparta.shippingservice.domain.model.trans.ShippingSelf;
 import com.sparta.shippingservice.domain.model.ShippingStatus;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;

--- a/shipping-service/src/main/java/com/sparta/shippingservice/application/dto/request/UpdateShippingRequestDto.java
+++ b/shipping-service/src/main/java/com/sparta/shippingservice/application/dto/request/UpdateShippingRequestDto.java
@@ -1,9 +1,8 @@
 package com.sparta.shippingservice.application.dto.request;
 
-import com.sparta.shippingservice.domain.model.ShippingSelf;
+import com.sparta.shippingservice.domain.model.trans.ShippingSelf;
 import com.sparta.shippingservice.domain.model.ShippingStatus;
 
-import java.util.Optional;
 import java.util.UUID;
 
 

--- a/shipping-service/src/main/java/com/sparta/shippingservice/application/service/ShippingService.java
+++ b/shipping-service/src/main/java/com/sparta/shippingservice/application/service/ShippingService.java
@@ -86,7 +86,6 @@ public class ShippingService {
 
     }
 
-
     @Transactional
     public ShippingResponseDto deleteShipping(UUID shippingId, long userId) {
         Shipping shipping = findShipping(shippingId);
@@ -98,10 +97,8 @@ public class ShippingService {
 
     @Transactional(readOnly = true)
     public ShippingRouteResponseDto getLogById(UUID shippingId, UUID shippingLogId){
-        ShippingRouteLog routeLog = shippingRouteRepository.findById(shippingLogId).orElseThrow(() -> new ResourceNotFoundException("찾을 수 없는 배송 로그 입니다."));
-        if(!routeLog.getShipping().getId().equals(shippingId)) {
-            throw new ResourceNotFoundException("해당 배송 ID에 해당하는 배송 경로 로그가 아닙니다.");
-        }
+        ShippingRouteLog routeLog = shippingRouteRepository.findByIdAndShippingId(shippingLogId, shippingId)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 배송에 속하지 않는 배송 경로 로그입니다."));
         return ShippingRouteResponseDto.from(routeLog);
 
     }

--- a/shipping-service/src/main/java/com/sparta/shippingservice/application/service/ShippingService.java
+++ b/shipping-service/src/main/java/com/sparta/shippingservice/application/service/ShippingService.java
@@ -7,6 +7,7 @@ import com.sparta.shippingservice.application.dto.response.ShippingResponseDto;
 import com.sparta.shippingservice.application.dto.response.ShippingRouteResponseDto;
 import com.sparta.shippingservice.application.dto.response.ShippingWithRouteResponseDto;
 import com.sparta.shippingservice.domain.model.*;
+import com.sparta.shippingservice.domain.model.trans.RouteLogSelf;
 import com.sparta.shippingservice.domain.repository.ShippingRepository;
 import com.sparta.commonmodule.exception.*;
 
@@ -32,7 +33,7 @@ public class ShippingService {
     @Transactional
     public ShippingWithRouteResponseDto create(@Valid CreateShippingRequestDto request , @Valid CreateRouteLogRequestDto logDto) {
         Shipping shipping = request.of().toShipping();
-        shippingRepository.save(shipping); //DB 저장
+
         RouteLogSelf routeLogSelf = new RouteLogSelf(
                 shipping,
                 logDto.startHubId(),
@@ -46,7 +47,12 @@ public class ShippingService {
 
         );
         ShippingRouteLog routeLog = routeLogSelf.toShippingRouteLog();
-        shippingRouteRepository.save(routeLog);
+
+        // 양방향 연관관계 설정
+        routeLog.setShipping(shipping);
+        shipping.getRouteLogs().add(routeLog);
+
+        shippingRepository.save(shipping);
         return ShippingWithRouteResponseDto.from(shipping,routeLog);
 
     }

--- a/shipping-service/src/main/java/com/sparta/shippingservice/domain/model/Shipping.java
+++ b/shipping-service/src/main/java/com/sparta/shippingservice/domain/model/Shipping.java
@@ -4,6 +4,8 @@ import com.sparta.commonmodule.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -28,6 +30,9 @@ public class Shipping extends BaseEntity {
 
     @Column(name = "shipping_manager_id", nullable = false)
     private UUID shippingManagerId;
+
+    @OneToMany(mappedBy = "shipping",cascade = CascadeType.PERSIST)
+    private List<ShippingRouteLog> routeLogs = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 50)

--- a/shipping-service/src/main/java/com/sparta/shippingservice/domain/model/trans/RouteLogSelf.java
+++ b/shipping-service/src/main/java/com/sparta/shippingservice/domain/model/trans/RouteLogSelf.java
@@ -1,4 +1,4 @@
-package com.sparta.shippingservice.domain.model;
+package com.sparta.shippingservice.domain.model.trans;
 
 import com.sparta.shippingservice.domain.model.Shipping;
 import com.sparta.shippingservice.domain.model.ShippingRouteLog;

--- a/shipping-service/src/main/java/com/sparta/shippingservice/domain/model/trans/ShippingSelf.java
+++ b/shipping-service/src/main/java/com/sparta/shippingservice/domain/model/trans/ShippingSelf.java
@@ -1,4 +1,7 @@
-package com.sparta.shippingservice.domain.model;
+package com.sparta.shippingservice.domain.model.trans;
+
+import com.sparta.shippingservice.domain.model.Shipping;
+import com.sparta.shippingservice.domain.model.ShippingStatus;
 
 import java.util.UUID;
 

--- a/shipping-service/src/main/java/com/sparta/shippingservice/domain/repository/ShippingRouteRepository.java
+++ b/shipping-service/src/main/java/com/sparta/shippingservice/domain/repository/ShippingRouteRepository.java
@@ -9,5 +9,6 @@ public interface ShippingRouteRepository {
     ShippingRouteLog save(ShippingRouteLog  shippingRouteLog);
     Optional<ShippingRouteLog> findById(UUID id);
     List<ShippingRouteLog> findAll();
+    Optional<ShippingRouteLog> findByIdAndShippingId(UUID id, UUID shippingId);
 
 }

--- a/shipping-service/src/main/java/com/sparta/shippingservice/presentation/ShippingController.java
+++ b/shipping-service/src/main/java/com/sparta/shippingservice/presentation/ShippingController.java
@@ -66,4 +66,6 @@ public class ShippingController {
         return ResponseEntity.ok(allLog);
 
     }
+//
+//    @DeleteMapping("{}")
 }


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [x] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [ ] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 변경 내용
* **as-is**
  * 배송 등록후 직접 배송 Log 배송 정보 DB 저장

* **to-be**
  * casecade.persist 설정해서 배송 저장하면 자동으로 배송 Log도 저장하도록 리팩토링
  * 배송로그 조회시 JPA를 통해 쿼리 한번으로 조회 가능하도록 메서드 추가 
## 💡 추가 설명

* 소프트 딜리트 때문에  고아객체 사라지지 않도록함

## 📚 참고 자료 (선택 사항)

* 관련 자료 링크
